### PR TITLE
Fix error running on windows

### DIFF
--- a/src/go.ts
+++ b/src/go.ts
@@ -4,7 +4,7 @@ import * as os from 'os'
 
 export function binPath(): string {
   if (os.platform() === 'win32') {
-    return 'main_windows.exe'
+    return path.join(__dirname,'main_windows.exe')
   }
   return path.join(__dirname, ['main_', os.platform()].join(''))
 }


### PR DESCRIPTION
On windows was reported the error:

```
Unable to locate executable file: main_windows.exe. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.
```

This is because windows has a different executioon path due to the
requirement of the `.exe` extension.
In thiis execution path, the executable name wa returned as relative
while in the other ones, iit was returned as relative