### PR TITLE
Push new dist file to the same PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,17 @@ jobs:
         go build -o dist/main_darwin test.go
     - uses: ./
 
-    # - uses: actions-go/push@v1
-    #   if: ${{ github.ref == "refs/heads/master" }}
-    #   with:
-    #     commit-message: '[Auto] update packaged index.js'
-    #     force: true
-    #     remote-ref: refs/heads/auto/build-dist
+  update-dist: # Publish the freshly built package
+    name: update dist file
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.event_name == 'push'  }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download assets
+      uses: actions/download-artifact@v2
+      with:
+        name: dist
+    - uses: actions-go/push@v1
+      with:
+        commit-message: '[Auto] update packaged index.js'


### PR DESCRIPTION
Pushing PRs from github workflows with the default GITHUB_TOKEN would
not trigger the required workflows to trigger the new testing and hence
would not allow tests to pass without having to force-merge.

Doing so, we ensure that the committed dist file is exactly the one that
has been tested in the PR, while not having to handle a custom service
user